### PR TITLE
Clean Dialog - use the new flags from SearchPattern for automatic infix search

### DIFF
--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
@@ -102,6 +102,12 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 	private static final String SHOW_DERIVED = "ShowDerived"; //$NON-NLS-1$
 	private static final String FILTER_BY_LOCATION = "FilterByLocation"; //$NON-NLS-1$
 
+	private static final char START_SYMBOL = '>';
+
+	private static final char END_SYMBOL = '<';
+
+	private static final char BLANK = ' ';
+
 	// TODO Bug 531785: Present the new autoInfixSearch feature on
 	// the UI layer somehow. Make it optional via a constructor?
 	private final boolean autoInfixSearch = true;
@@ -1023,7 +1029,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 		private ResourceFilter(IContainer container, IContainer searchContainer, boolean showDerived, int typeMask) {
 			this(container, showDerived, typeMask);
 
-			String stringPattern = patternMatcher.getInitialPattern();
+			final String stringPattern = patternMatcher.getInitialPattern();
 			String filenamePattern;
 
 			int sep = stringPattern.lastIndexOf(IPath.SEPARATOR);
@@ -1038,7 +1044,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 					if (filenamePattern.isEmpty()) // relative patterns don't need a file name
 						filenamePattern = "**"; //$NON-NLS-1$
 
-					String containerPattern = stringPattern.substring(patternMatcher.isMatchPrefix() ? 1 : 0, sep);
+					String containerPattern = stringPattern.substring(isMatchPrefix(stringPattern) ? 1 : 0, sep);
 
 					if (searchContainer != null) {
 						relativeContainerPattern = new SearchPattern(
@@ -1059,7 +1065,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 							| SearchPattern.RULE_PREFIX_MATCH | SearchPattern.RULE_PATTERN_MATCH);
 					this.containerPattern.setPattern(containerPattern);
 				}
-				if (patternMatcher.isMatchPrefix()) {
+				if (isMatchPrefix(stringPattern)) {
 					filenamePattern = '>' + filenamePattern;
 				}
 				patternMatcher.setPattern(filenamePattern);
@@ -1074,7 +1080,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 				// `patternMatcher`).
 				namePattern = new SearchPattern(getDefaultMatchRules());
 				String namePatternStr = filenamePattern.substring(0, lastPatternDot);
-				if (patternMatcher.isMatchSuffix() && !namePatternStr.endsWith("*")) { //$NON-NLS-1$
+				if (isMatchSuffix(stringPattern) && !namePatternStr.endsWith("*")) { //$NON-NLS-1$
 					// This means extension part will end with '<' (or ' ')
 					// and we should apply the same for the name part.
 					namePatternStr += "<"; //$NON-NLS-1$
@@ -1259,6 +1265,31 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			resourceFactory.saveState(element);
 		}
 
+	}
+
+	/**
+	 * Returns whether prefix matching is enforced in the given search pattern.
+	 */
+	private static boolean isMatchPrefix(String pattern) {
+		if (pattern.length() == 0) {
+			return false;
+		}
+
+		char first = pattern.charAt(0);
+		return pattern.length() > 1 && first == START_SYMBOL;
+	}
+
+	/**
+	 * Returns whether suffix matching is enforced in the given search pattern.
+	 */
+	private static boolean isMatchSuffix(String pattern) {
+		if (pattern.length() <= 1) {
+			return false;
+		}
+
+		char last = pattern.charAt(pattern.length() - 1);
+		boolean matchPrefix = isMatchPrefix(pattern);
+		return pattern.length() > (matchPrefix ? 2 : 1) && (last == END_SYMBOL || last == BLANK);
 	}
 
 }

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
@@ -108,8 +108,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 
 	private static final char BLANK = ' ';
 
-	// TODO Bug 531785: Present the new autoInfixSearch feature on
-	// the UI layer somehow. Make it optional via a constructor?
+	// this is hard-coded, as a UI option is most probably not necessary
 	private final boolean autoInfixSearch = true;
 
 	private int getDefaultMatchRules() {

--- a/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
+++ b/bundles/org.eclipse.ui.ide/extensions/org/eclipse/ui/dialogs/FilteredResourcesSelectionDialog.java
@@ -102,6 +102,14 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 	private static final String SHOW_DERIVED = "ShowDerived"; //$NON-NLS-1$
 	private static final String FILTER_BY_LOCATION = "FilterByLocation"; //$NON-NLS-1$
 
+	// TODO Bug 531785: Present the new autoInfixSearch feature on
+	// the UI layer somehow. Make it optional via a constructor?
+	private final boolean autoInfixSearch = true;
+
+	private int getDefaultMatchRules() {
+		return SearchPattern.DEFAULT_MATCH_RULES | (autoInfixSearch ? SearchPattern.RULE_SUBSTRING_MATCH : 0);
+	}
+
 	private ShowDerivedResourcesAction showDerivedResourcesAction;
 
 	private ResourceItemLabelProvider resourceItemLabelProvider;
@@ -443,6 +451,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 
 			if (pattern != null) {
 				int patternDot = pattern.lastIndexOf('.');
+				// Prioritize names matching the whole pattern
 				String patternNoExtension = patternDot == -1 ? pattern : pattern.substring(0, patternDot);
 				boolean m1 = patternNoExtension.equals(n1);
 				boolean m2 = patternNoExtension.equals(n2);
@@ -452,6 +461,21 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 					}
 					if (m2) {
 						return 1;
+					}
+				}
+				// Prioritize names starting with the pattern
+				char patternFirstChar = getFirstFileNameChar(pattern);
+				if (patternFirstChar != 0) {
+					patternFirstChar = Character.toLowerCase(patternFirstChar);
+					m1 = patternFirstChar == Character.toLowerCase(s1.charAt(0));
+					m2 = patternFirstChar == Character.toLowerCase(s2.charAt(0));
+					if (!m1 || !m2) {
+						if (m1) {
+							return -1;
+						}
+						if (m2) {
+							return 1;
+						}
 					}
 				}
 			}
@@ -493,6 +517,22 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 
 			return comparability;
 		};
+	}
+
+	/**
+	 * @param pattern
+	 * @return the first character from the given string which <em>could</em> be
+	 *         considered a part of a file name. Returns <code>0</code> if there is
+	 *         no such character found.
+	 */
+	private char getFirstFileNameChar(String pattern) {
+		for (int i = 0; i < pattern.length(); i++) {
+			char ch = pattern.charAt(i);
+			if (ch != '*') {
+				return ch;
+			}
+		}
+		return 0;
 	}
 
 	/**
@@ -722,6 +762,9 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			}
 
 			// Pre-process the matching pattern
+			if (matching.charAt(0) == '>') {
+				matching = matching.substring(1);
+			}
 			char lastChar = matching.charAt(matching.length() - 1);
 			if (lastChar == ' ' || lastChar == '<') {
 				matching = matching.substring(0, matching.length() - 1);
@@ -756,8 +799,11 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 			if (regionsDontMatch) {
 				// We should get here only when CamelCase nor wildcard matching succeeded
 				// A simple comparison of the whole strings should succeed instead
-				if (string.toLowerCase().startsWith(matching.toLowerCase())) {
-					positions.add(new Position(0, matching.length()));
+				int matchingIndex = autoInfixSearch
+						? string.toLowerCase().indexOf(matching.toLowerCase())
+						: (string.toLowerCase().startsWith(matching.toLowerCase()) ? 0 : -1);
+				if (matchingIndex > -1) {
+					positions.add(new Position(matchingIndex, matching.length()));
 				}
 			}
 			return positions;
@@ -959,7 +1005,7 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 		 * @param typeMask    filter type mask. See {@link IResource#getType()} types.
 		 */
 		public ResourceFilter(IContainer container, boolean showDerived, int typeMask) {
-			super();
+			super(new SearchPattern(getDefaultMatchRules()));
 			this.filterContainer = container;
 			this.showDerived = showDerived;
 			this.filterTypeMask = typeMask;
@@ -977,21 +1023,22 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 		private ResourceFilter(IContainer container, IContainer searchContainer, boolean showDerived, int typeMask) {
 			this(container, showDerived, typeMask);
 
-			String stringPattern = getPattern();
-			int matchRule = getMatchRule();
+			String stringPattern = patternMatcher.getInitialPattern();
 			String filenamePattern;
 
 			int sep = stringPattern.lastIndexOf(IPath.SEPARATOR);
 			if (sep != -1) {
+				// This means that we primarily check (via `patternMatcher`) just the resource
+				// _name_ part and when there is some actual _container_ part (`sep > 0`), we
+				// also do checks for that part (via `containerPattern` and optional
+				// `relativeContainerPattern`).
 				filenamePattern = stringPattern.substring(sep + 1, stringPattern.length());
-				if ("*".equals(filenamePattern)) //$NON-NLS-1$
-					filenamePattern = "**"; //$NON-NLS-1$
 
 				if (sep > 0) {
 					if (filenamePattern.isEmpty()) // relative patterns don't need a file name
 						filenamePattern = "**"; //$NON-NLS-1$
 
-					String containerPattern = stringPattern.substring(0, sep);
+					String containerPattern = stringPattern.substring(patternMatcher.isMatchPrefix() ? 1 : 0, sep);
 
 					if (searchContainer != null) {
 						relativeContainerPattern = new SearchPattern(
@@ -1001,6 +1048,8 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 					}
 
 					if (!containerPattern.startsWith(Character.toString('*'))) {
+						// bug 552418 - make the search always "root less", so that users don't need to
+						// type the initial "*/"
 						if (!containerPattern.startsWith(Character.toString(IPath.SEPARATOR))) {
 							containerPattern = IPath.SEPARATOR + containerPattern;
 						}
@@ -1010,35 +1059,29 @@ public class FilteredResourcesSelectionDialog extends FilteredItemsSelectionDial
 							| SearchPattern.RULE_PREFIX_MATCH | SearchPattern.RULE_PATTERN_MATCH);
 					this.containerPattern.setPattern(containerPattern);
 				}
-				boolean isPrefixPattern = matchRule == SearchPattern.RULE_PREFIX_MATCH
-						|| (matchRule == SearchPattern.RULE_PATTERN_MATCH && filenamePattern.endsWith("*")); //$NON-NLS-1$
-				if (!isPrefixPattern)
-					// Add '<' again as it was removed by SearchPattern
-					filenamePattern += '<';
-				else if (filenamePattern.endsWith("*") && !filenamePattern.equals("**")) //$NON-NLS-1$ //$NON-NLS-2$
-					// Remove added '*' as the filename pattern might be a camel case pattern
-					filenamePattern = filenamePattern.substring(0, filenamePattern.length() - 1);
+				if (patternMatcher.isMatchPrefix()) {
+					filenamePattern = '>' + filenamePattern;
+				}
 				patternMatcher.setPattern(filenamePattern);
-				// Update filenamePattern and matchRule as they might have changed
-				filenamePattern = getPattern();
-				matchRule = getMatchRule();
 			} else {
 				filenamePattern = stringPattern;
 			}
 
 			int lastPatternDot = filenamePattern.lastIndexOf('.');
 			if (lastPatternDot != -1) {
-				if (matchRule != SearchPattern.RULE_EXACT_MATCH) {
-					namePattern = new SearchPattern();
-					namePattern.setPattern(filenamePattern.substring(0, lastPatternDot));
-					String extensionPatternStr = filenamePattern.substring(lastPatternDot + 1);
-					// Add a '<' except this is a camel case pattern or a prefix pattern
-					if (matchRule != SearchPattern.RULE_CAMELCASE_MATCH && matchRule != SearchPattern.RULE_PREFIX_MATCH
-							&& !extensionPatternStr.endsWith("*")) //$NON-NLS-1$
-						extensionPatternStr += '<';
-					extensionPattern = new SearchPattern();
-					extensionPattern.setPattern(extensionPatternStr);
+				// This means we primarily check resource name as _name_ and _extension_ part
+				// and only when we don't succeed, we try the default whole-name check (via
+				// `patternMatcher`).
+				namePattern = new SearchPattern(getDefaultMatchRules());
+				String namePatternStr = filenamePattern.substring(0, lastPatternDot);
+				if (patternMatcher.isMatchSuffix() && !namePatternStr.endsWith("*")) { //$NON-NLS-1$
+					// This means extension part will end with '<' (or ' ')
+					// and we should apply the same for the name part.
+					namePatternStr += "<"; //$NON-NLS-1$
 				}
+				namePattern.setPattern(namePatternStr);
+				extensionPattern = new SearchPattern();
+				extensionPattern.setPattern(filenamePattern.substring(lastPatternDot + 1));
 			}
 
 		}

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/CleanDialog.java
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/dialogs/CleanDialog.java
@@ -103,7 +103,8 @@ public class CleanDialog extends MessageDialog {
 	private IWorkbenchWindow window;
 
 	private Text filterText;
-	private SearchPattern searchPattern = new SearchPattern();
+	private SearchPattern searchPattern = new SearchPattern(
+			SearchPattern.DEFAULT_MATCH_RULES | SearchPattern.RULE_SUBSTRING_MATCH);
 
 	/**
 	 * Gets the text of the clean dialog, depending on whether the
@@ -220,11 +221,7 @@ public class CleanDialog extends MessageDialog {
 		filterText.setLayoutData(gd);
 		filterText.addModifyListener(e -> {
 			String filter = filterText.getText();
-			if (filter.startsWith("*") || filter.startsWith("?")) { //$NON-NLS-1$ //$NON-NLS-2$
-				searchPattern.setPattern(filter);
-			} else {
-				searchPattern.setPattern("*" + filter); //$NON-NLS-1$
-			}
+			searchPattern.setPattern(filter);
 
 			if (filter.isEmpty()) {
 				filterText.setMessage(IDEWorkbenchMessages.CleanDialog_typeFilterText);

--- a/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
+++ b/bundles/org.eclipse.ui.ide/src/org/eclipse/ui/internal/ide/messages.properties
@@ -865,7 +865,7 @@ ResourceSelectionDialog_folders = In &folders:
 ResourceSelectionDialog_showDerived=Show &derived resources
 
 OpenResourceDialog_title = Open Resource
-OpenResourceDialog_message = &Enter resource name prefix, path prefix or pattern (?, * or camel case):
+OpenResourceDialog_message = &Enter resource name, path or pattern (?, * or camel case):
 OpenResourceDialog_openButton_text = &Open
 OpenResourceDialog_openWithButton_text=Open Wit&h
 OpenResourceDialog_openWithMenu_label=Open Wit&h

--- a/bundles/org.eclipse.ui.workbench/.settings/.api_filters
+++ b/bundles/org.eclipse.ui.workbench/.settings/.api_filters
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.ui.workbench" version="2">
+    <resource path="Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java" type="org.eclipse.ui.dialogs.SearchPattern">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.dialogs.SearchPattern"/>
+                <message_argument value="DEFAULT_MATCH_RULES"/>
+            </message_arguments>
+        </filter>
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.ui.dialogs.SearchPattern"/>
+                <message_argument value="RULE_SUBSTRING_MATCH"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="META-INF/MANIFEST.MF">
         <filter comment="planned-databinding-API-deletion" id="926941240">
             <message_arguments>

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
@@ -18,12 +18,9 @@ import org.eclipse.ui.internal.misc.TextMatcher;
 
 /**
  * A search pattern defines how search results are found.
- *
  * <p>
  * This class is intended to be subclassed by clients. A default behavior is
- * provided for each of the methods above, that clients can override if they
- * wish.
- * </p>
+ * provided that clients can override if they wish.
  *
  * @since 3.3
  */
@@ -39,8 +36,6 @@ public class SearchPattern {
 
 	/**
 	 * Match rule: The search pattern is a prefix of the search result.
-	 * <p>
-	 * This is the <em>default</em> match rule if no other applies.
 	 */
 	public static final int RULE_PREFIX_MATCH = 0x0001;
 
@@ -49,11 +44,11 @@ public class SearchPattern {
 	 * A '*' wild-card can replace 0 or more characters in the search result. A '?'
 	 * wild-card replaces exactly 1 character in the search result.
 	 * <p>
-	 * Unless the pattern ends with ' ' or '>', '*' is automatically added to the
-	 * end of the pattern.
+	 * Unless the pattern ends with ' ' or '>', search is performed as if '*' was
+	 * specified at the end of the pattern.
 	 * <p>
-	 * When {@link #RULE_SUBSTRING_MATCH} is in effect, then '*' is automatically
-	 * added to the start of the pattern.
+	 * When {@link #RULE_SUBSTRING_MATCH} is in effect, search is performed as if
+	 * '*' was specified at the start of the pattern.
 	 */
 	public static final int RULE_PATTERN_MATCH = 0x0002;
 
@@ -62,7 +57,6 @@ public class SearchPattern {
 	 * the same. Can be combined with previous rules, e.g. {@link #RULE_EXACT_MATCH}
 	 * | {@link #RULE_CASE_SENSITIVE}.
 	 */
-	// TODO The actual code seems to ignore this flag when performing searches.
 	public static final int RULE_CASE_SENSITIVE = 0x0008;
 
 	/**
@@ -146,10 +140,8 @@ public class SearchPattern {
 	private boolean matchSuffix;
 
 	/**
-	 * Creates a new instance of SearchPattern with the following match rules
-	 * configured: {@link #RULE_EXACT_MATCH} | {@link #RULE_PREFIX_MATCH} |
-	 * {@link #RULE_PATTERN_MATCH} | {@link #RULE_CAMELCASE_MATCH} |
-	 * {@link #RULE_BLANK_MATCH}.
+	 * Creates a new instance of SearchPattern with {@link #DEFAULT_MATCH_RULES
+	 * default set of rules} configured.
 	 */
 	public SearchPattern() {
 		this(DEFAULT_MATCH_RULES);
@@ -175,8 +167,6 @@ public class SearchPattern {
 	 *                     if a prefix non case sensitive match is requested or
 	 *                     {@link #RULE_EXACT_MATCH} if a non case sensitive and
 	 *                     erasure match is requested.<br>
-	 *                     Note also that default behavior for generic types/methods
-	 *                     search is to find prefix matches.
 	 */
 	public SearchPattern(int allowedRules) {
 		this.allowedRules = allowedRules;
@@ -216,10 +206,19 @@ public class SearchPattern {
 	}
 
 	/**
-	 * Matches text with pattern. matching is determine by matchKind.
+	 * Matches text with pattern. The way of matching is determined by the current
+	 * pattern setup - see {@link #getMatchRule()} for details.
+	 * <p>
+	 * If no rule applies or when {@link #RULE_CAMELCASE_MATCH} applies, but the
+	 * text doesn't match it, the default implementation of this method performs a
+	 * simple prefix, suffix, or substring matching (determined by the pattern
+	 * setup).
+	 * <p>
+	 * The default implementation generally does only case-insensitive searches,
+	 * i.e. {@link #RULE_CASE_SENSITIVE} is not considered here.
 	 *
 	 * @param text the text to match
-	 * @return true if search pattern was matched with text false in other way
+	 * @return true if search pattern was matched with text, false otherwise
 	 */
 	public boolean matches(String text) {
 		switch (matchRule) {
@@ -732,7 +731,6 @@ public class SearchPattern {
 	 * <i>WARNING: This method is <b>not</b> defined in reading order, i.e.
 	 * <code>a.isSubPattern(b)</code> is <code>true</code> iff <code>b</code> is a
 	 * sub-pattern of <code>a</code>, and not vice-versa. </i>
-	 * </p>
 	 *
 	 * @param pattern pattern to be checked
 	 * @return true if the given pattern is a sub pattern of this search pattern

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
@@ -61,9 +61,8 @@ public class SearchPattern {
 	 * Match rule: The search pattern matches the search result only if cases are
 	 * the same. Can be combined with previous rules, e.g. {@link #RULE_EXACT_MATCH}
 	 * | {@link #RULE_CASE_SENSITIVE}.
-	 * <p>
-	 * TODO The actual code seems to ignore this flag when performing searches.
 	 */
+	// TODO The actual code seems to ignore this flag when performing searches.
 	public static final int RULE_CASE_SENSITIVE = 0x0008;
 
 	/**
@@ -110,14 +109,14 @@ public class SearchPattern {
 	 * pattern. Analogically, suffix search may be enforced by placing ' ' or '&lt;'
 	 * at the end of the pattern.
 	 *
-	 * @since 3.126
+	 * @since 3.127
 	 */
 	public static final int RULE_SUBSTRING_MATCH = 0x0200;
 
 	/**
 	 * The default set of match rules as used by the no-argument constructor.
-	 * 
-	 * @since 3.126
+	 *
+	 * @since 3.127
 	 */
 	public static final int DEFAULT_MATCH_RULES = RULE_EXACT_MATCH | RULE_PREFIX_MATCH | RULE_PATTERN_MATCH
 			| RULE_CAMELCASE_MATCH | RULE_BLANK_MATCH;
@@ -157,24 +156,27 @@ public class SearchPattern {
 	}
 
 	/**
-	 * Creates a search pattern with the rule to apply for matching index keys. It
-	 * can be exact match, prefix match, pattern match or camelCase match. Rule can
-	 * also be combined with a case sensitivity flag.
+	 * Creates a search pattern with a rule or rules to apply for matching index keys.
 	 *
 	 * @param allowedRules one of {@link #RULE_EXACT_MATCH},
-	 *                     {@link #RULE_PREFIX_MATCH}, {@link #RULE_PATTERN_MATCH},
-	 *                     {@link #RULE_CASE_SENSITIVE},
-	 *                     {@link #RULE_CAMELCASE_MATCH} combined with one of
-	 *                     following values: {@link #RULE_EXACT_MATCH},
-	 *                     {@link #RULE_PREFIX_MATCH}, {@link #RULE_PATTERN_MATCH}
-	 *                     or {@link #RULE_CAMELCASE_MATCH}. e.g.
-	 *                     {@link #RULE_EXACT_MATCH} | {@link #RULE_CASE_SENSITIVE}
-	 *                     if an exact and case sensitive match is requested,
-	 *                     {@link #RULE_PREFIX_MATCH} if a prefix non case sensitive
-	 *                     match is requested or {@link #RULE_EXACT_MATCH} if a non
-	 *                     case sensitive and erasure match is requested.<br>
+	 *                     {@link #RULE_PREFIX_MATCH},
+	 *                     {@link #RULE_SUBSTRING_MATCH},
+	 *                     {@link #RULE_PATTERN_MATCH},
+	 *                     {@link #RULE_CAMELCASE_MATCH},
+	 *                     {@link #RULE_CASE_SENSITIVE}, or their combination in
+	 *                     order to enable more types of matching. Note that rules
+	 *                     {@link #RULE_CASE_SENSITIVE} and
+	 *                     {@link #RULE_SUBSTRING_MATCH} are special in that they
+	 *                     generally just affect how the other match rules
+	 *                     behave.<br>
+	 *                     Examples: {@link #RULE_EXACT_MATCH} |
+	 *                     {@link #RULE_CASE_SENSITIVE} if an exact and case
+	 *                     sensitive match is requested, {@link #RULE_PREFIX_MATCH}
+	 *                     if a prefix non case sensitive match is requested or
+	 *                     {@link #RULE_EXACT_MATCH} if a non case sensitive and
+	 *                     erasure match is requested.<br>
 	 *                     Note also that default behavior for generic types/methods
-	 *                     search is to find exact matches.
+	 *                     search is to find prefix matches.
 	 */
 	public SearchPattern(int allowedRules) {
 		this.allowedRules = allowedRules;
@@ -194,7 +196,7 @@ public class SearchPattern {
 	 * Gets the initial (input) string pattern.
 	 *
 	 * @return pattern
-	 * @since 3.126
+	 * @since 3.127
 	 */
 	public String getInitialPattern() {
 		return this.initialPattern;
@@ -616,15 +618,13 @@ public class SearchPattern {
 	}
 
 	/**
-	 * Returns the rule to apply for matching keys. Can be exact match, prefix
-	 * match, pattern match or camelcase match. Rule can also be combined with a
-	 * case sensitivity flag.
+	 * Returns the active rule to apply for matching keys, based on the currently
+	 * set {@link #setPattern(String) pattern} and allowed rules passed to the
+	 * {@link #SearchPattern(int) constructor}.
 	 *
-	 * @return one of RULE_EXACT_MATCH, RULE_PREFIX_MATCH, RULE_PATTERN_MATCH,
-	 *         RULE_CAMELCASE_MATCH, combined with RULE_CASE_SENSITIVE, e.g.
-	 *         RULE_EXACT_MATCH | RULE_CASE_SENSITIVE if an exact and case sensitive
-	 *         match is requested, or RULE_PREFIX_MATCH if a prefix non case
-	 *         sensitive match is requested.
+	 * @return one of {@link #RULE_BLANK_MATCH}, {@link #RULE_EXACT_MATCH},
+	 *         {@link #RULE_PREFIX_MATCH}, {@link #RULE_PATTERN_MATCH},
+	 *         {@link #RULE_CAMELCASE_MATCH}
 	 */
 	public final int getMatchRule() {
 		return this.matchRule;
@@ -632,7 +632,7 @@ public class SearchPattern {
 
 	/**
 	 * @return whether prefix matching is enforced
-	 * @since 3.126
+	 * @since 3.127
 	 */
 	public boolean isMatchPrefix() {
 		return matchPrefix;
@@ -640,7 +640,7 @@ public class SearchPattern {
 
 	/**
 	 * @return whether suffix matching is enforced
-	 * @since 3.126
+	 * @since 3.127
 	 */
 	public boolean isMatchSuffix() {
 		return matchSuffix;

--- a/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
+++ b/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/SearchPattern.java
@@ -252,8 +252,7 @@ public class SearchPattern {
 	}
 
 	private void initializePatternAndMatchRule(String pattern) {
-		int length = pattern.length();
-		if (length == 0) {
+		if (pattern.length() == 0) {
 			matchRule = RULE_BLANK_MATCH;
 			stringPattern = pattern;
 			return;
@@ -261,7 +260,7 @@ public class SearchPattern {
 
 		// pre-process the string pattern
 		char first = pattern.charAt(0);
-		char last = pattern.charAt(length - 1);
+		char last = pattern.charAt(pattern.length() - 1);
 		// note: a file name might start with a space => we can't use it for enforcing prefix match
 		matchPrefix = pattern.length() > 1 && first == START_SYMBOL;
 		matchSuffix = pattern.length() > (matchPrefix ? 2 : 1) && (last == END_SYMBOL || last == BLANK);
@@ -628,22 +627,6 @@ public class SearchPattern {
 	 */
 	public final int getMatchRule() {
 		return this.matchRule;
-	}
-
-	/**
-	 * @return whether prefix matching is enforced
-	 * @since 3.127
-	 */
-	public boolean isMatchPrefix() {
-		return matchPrefix;
-	}
-
-	/**
-	 * @return whether suffix matching is enforced
-	 * @since 3.127
-	 */
-	public boolean isMatchSuffix() {
-		return matchSuffix;
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/AbstractSearchPatternAuto.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/AbstractSearchPatternAuto.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2017 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Petr Bodnar - common ancestor for SearchPattern test classes
+ *******************************************************************************/
+
+package org.eclipse.ui.tests.dialogs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.eclipse.ui.dialogs.SearchPattern;
+import org.junit.Test;
+
+/**
+ * Common ancestor for tests of the SearchPattern's match functionality.
+ */
+public abstract class AbstractSearchPatternAuto {
+
+	/**
+	 * Items to be filtered.
+	 */
+	protected static List<String> resources = new ArrayList<>();
+
+	static {
+		generateResourcesTestCases('A', 'C', 8, "");
+		generateResourcesTestCases('A', 'C', 4, "");
+		// add some explicit testing samples:
+		resources.addAll(
+				Arrays.asList("BC", "BCD", "AiBiCiDi", "BiCiDi", "BijCiDi", "BICI", "abc", "bcd", "abcd", "ab cd"));
+		// in practice, there should be no resources with such names, but for
+		// completeness:
+		resources.addAll(Arrays.asList(" ", "AB ", ">", "<"));
+		// ... while this might exist:
+		resources.add(" BC");
+	}
+
+	/**
+	 * Generates strings data for match test cases.
+	 *
+	 * @param startChar
+	 * @param endChar
+	 * @param length
+	 * @param resource
+	 */
+	protected static void generateResourcesTestCases(char startChar, char endChar, int length, String resource) {
+		for (char ch = startChar; ch <= endChar; ch++) {
+			String res = resource + ch;
+			if (length == res.length()) {
+				resources.add(res);
+			} else if ((res.trim().length() % 2) == 0) {
+				generateResourcesTestCases(Character.toUpperCase((char) (startChar + 1)),
+						Character.toUpperCase((char) (endChar + 1)), length, res);
+			} else {
+				generateResourcesTestCases(Character.toLowerCase((char) (startChar + 1)),
+						Character.toLowerCase((char) (endChar + 1)), length, res);
+			}
+		}
+	}
+
+	/**
+	 * Empty pattern matches everything. In practice, no search is done in this case
+	 * though.
+	 */
+	@Test
+	public void testBlankMatch() {
+		Pattern pattern = Pattern.compile(".*", Pattern.CASE_INSENSITIVE);
+		assertMatches("", SearchPattern.RULE_BLANK_MATCH, pattern);
+	}
+
+	/**
+	 * Tests that a single "&lt;" is taken as a plain character. For simplicity, we
+	 * emulate just a perfect match here.
+	 */
+	@Test
+	public void testJustEndCharPattern() {
+		Pattern pattern = Pattern.compile("<", Pattern.CASE_INSENSITIVE);
+		assertMatches("<", SearchPattern.RULE_PREFIX_MATCH, pattern);
+	}
+
+	/**
+	 * Tests that a single "&gt;" is taken as a plain character. For simplicity, we
+	 * emulate just a perfect match here.
+	 */
+	@Test
+	public void testJustStartCharPattern() {
+		Pattern pattern = Pattern.compile(">", Pattern.CASE_INSENSITIVE);
+		assertMatches(">", SearchPattern.RULE_PREFIX_MATCH, pattern);
+	}
+
+	@Test
+	public void testIsSubPattern_BasicCases() {
+		SearchPattern prevPattern = createSearchPattern("a");
+		SearchPattern nextPattern = createSearchPattern("ab");
+		assertTrue("[ab] has to be a sub-pattern of [a]", prevPattern.isSubPattern(nextPattern));
+		assertFalse("[a] must not be a sub-pattern of [ab]", nextPattern.isSubPattern(prevPattern));
+	}
+
+	/**
+	 * Tests this scenario: user types in ">" and then "a" - the resulting ">a"
+	 * pattern must NOT be evaluated as a sub-pattern of ">", because searching just
+	 * by ">" should normally return an empty set - and filtering just that empty
+	 * set would find nothing.
+	 */
+	@Test
+	public void testIsSubPattern_WhenPrevIsJustStartChar_ReturnFalse() {
+		SearchPattern prevPattern = createSearchPattern(">");
+		SearchPattern nextPattern = createSearchPattern(">a");
+		assertFalse(prevPattern.isSubPattern(nextPattern));
+	}
+
+	protected abstract SearchPattern createSearchPattern();
+
+	protected SearchPattern createSearchPattern(String inputPattern) {
+		SearchPattern pattern = createSearchPattern();
+		pattern.setPattern(inputPattern);
+		return pattern;
+	}
+
+	protected void assertMatches(String patternText, int expectedMatchRule, Pattern... matchingPatterns) {
+		SearchPattern patternMatcher = createSearchPattern();
+		patternMatcher.setPattern(patternText);
+		assertEquals("Inferred match rule must match", expectedMatchRule, patternMatcher.getMatchRule());
+		boolean someMatch = false;
+		for (String res : resources) {
+			boolean anyMatches = anyMatches(res, matchingPatterns);
+			boolean patternMatches = patternMatcher.matches(res);
+			if (patternMatches) {
+				assertTrue("Pattern '" + patternText + "' matches '" + res + "', but it shouldn't.", anyMatches);
+			} else {
+				assertFalse("Pattern '" + patternText + "' doesn't match '" + res + "', but it should.", anyMatches);
+			}
+			if (anyMatches) {
+				someMatch = true;
+			}
+		}
+		if (!someMatch) {
+			fail("Invalid test setup: no item matches any of the supplied matchingPatterns");
+		}
+	}
+
+	protected static boolean anyMatches(String res, Pattern... patterns) {
+		for (Pattern pattern : patterns) {
+			if (pattern.matcher(res).matches()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceItemLabelTest.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/ResourceItemLabelTest.java
@@ -82,6 +82,19 @@ public class ResourceItemLabelTest extends UITestCase {
 	}
 
 	/**
+	 * Tests that the highlighting matches basic substrings when infix search is
+	 * automatically performed.
+	 */
+	@Test
+	public void testSubstringMatch_withAutoInfix() throws Exception {
+		Position[] atEnd = { new Position(2, 6) };
+		compareStyleRanges(atEnd, getStyleRanges("st.txt", "test.txt"), "test.txt", "");
+
+		Position[] atEndDifferentCase = { new Position(2, 6) };
+		compareStyleRanges(atEndDifferentCase, getStyleRanges("ST.txt", "test.txt"), "test.txt", "");
+	}
+
+	/**
 	 * Tests that the highlighting matches CamelCase searches
 	 *
 	 * @throws Exception
@@ -102,6 +115,17 @@ public class ResourceItemLabelTest extends UITestCase {
 
 		Position[] skippingDigit = { new Position(0, 2), new Position(5, 1) };
 		compareStyleRanges(skippingDigit, getStyleRanges("ThT", "This3Test.txt"), "This3Test.txt", "");
+
+	}
+
+	/**
+	 * Tests that the highlighting matches CamelCase searches when infix search is
+	 * automatically performed.
+	 */
+	@Test
+	public void testCamelCaseMatch_withAutoInfix() throws Exception {
+		Position[] atEnd = { new Position(4, 1), new Position(6, 1) };
+		compareStyleRanges(atEnd, getStyleRanges("IT", "ThisIsTest.txt"), "ThisIsTest.txt", "");
 	}
 
 	/**
@@ -122,6 +146,16 @@ public class ResourceItemLabelTest extends UITestCase {
 
 		Position[] withDigits = { new Position(0, 1), new Position(2, 2), new Position(7, 3) };
 		compareStyleRanges(withDigits, getStyleRanges("t?s3*x3t", "tes3t.tx3t"), "tes3t.tx3t", "");
+	}
+
+	/**
+	 * Tests that the highlighting matches searches using '*' and '?' when infix
+	 * search is automatically performed.
+	 */
+	@Test
+	public void testPatternMatch_withAutoInfix() throws Exception {
+		Position[] atEnd = { new Position(1, 1), new Position(3, 2) };
+		compareStyleRanges(atEnd, getStyleRanges("t?st", "atest.txt"), "atest.txt", "");
 	}
 
 	/**
@@ -153,6 +187,21 @@ public class ResourceItemLabelTest extends UITestCase {
 
 		Position[] both = { new Position(0, 3), new Position(6, 1) };
 		compareStyleRanges(both, getStyleRanges("CreS<", "CreateStuff.java"), "CreateStuff.java", "");
+	}
+
+	/**
+	 * Tests that the highlighting matches searches using '&lt;'.
+	 */
+	@Test
+	public void testDisableAutoInfixMatching() throws Exception {
+		Position[] substring = { new Position(0, 4) };
+		compareStyleRanges(substring, getStyleRanges(">make", "Makefile"), "Makefile", "");
+
+		Position[] pattern = { new Position(0, 1), new Position(4, 4) };
+		compareStyleRanges(pattern, getStyleRanges(">M*file", "Makefile"), "Makefile", "");
+
+		Position[] camelCase = { new Position(0, 3), new Position(6, 1) };
+		compareStyleRanges(camelCase, getStyleRanges(">CreS", "CreateStuff.java"), "CreateStuff.java", "");
 	}
 
 	/**

--- a/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIAutomatedSuite.java
+++ b/tests/org.eclipse.ui.tests/Eclipse UI Tests/org/eclipse/ui/tests/dialogs/UIAutomatedSuite.java
@@ -22,7 +22,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({ UIDialogsAuto.class, DeprecatedUIDialogsAuto.class, UIWizardsAuto.class,
 		DeprecatedUIWizardsAuto.class, UIPreferencesAuto.class, UIComparePreferencesAuto.class,
 		DeprecatedUIPreferencesAuto.class, UIMessageDialogsAuto.class, UINewWorkingSetWizardAuto.class,
-		UIEditWorkingSetWizardAuto.class, SearchPatternAuto.class, UIFilteredResourcesSelectionDialogAuto.class,
+		UIEditWorkingSetWizardAuto.class, SearchPatternAuto.class, InfixSearchPatternAuto.class,
+		UIFilteredResourcesSelectionDialogAuto.class,
 		TreeManagerTest.class, ContainerCheckedTreeViewerTest.class })
 public class UIAutomatedSuite {
 


### PR DESCRIPTION
(a preview PR)

This not only simplifies the implementation, but also gives users the ability to use prefix search - by specifying '>' as the 1st filter character.

This builds on top of eclipse-platform/eclipse.platform.ui/pull/12.